### PR TITLE
fix add resource to v1 module and export typeorm module in resource m…

### DIFF
--- a/server/src/v1/resource/resource.module.ts
+++ b/server/src/v1/resource/resource.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { ResourceEntity } from './resource.entity.js';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ResourceController } from './resource.controller.js';
+import { ResourceService } from './resource.service.js';
 
 @Module({
   imports: [TypeOrmModule.forFeature([ResourceEntity])],
-  exports: [ResourceEntity],
+  controllers: [ResourceController],
+  providers: [ResourceService],
+  exports: [TypeOrmModule],
 })
 export class ResourceModule {}

--- a/server/src/v1/v1.module.ts
+++ b/server/src/v1/v1.module.ts
@@ -4,6 +4,7 @@ import { SubSubjectModule } from './sub-subject/sub-subject.module.js';
 import { UserModule } from './user/user.module.js';
 import { UserTypeModule } from './user-type/user-type.module.js';
 import { TagModule } from './tag/tag.module.js';
+import { ResourceModule } from './resource/resource.module.js';
 
 const logger = new Logger('v1Module');
 logger.log('Hitting v1.module');
@@ -15,6 +16,7 @@ logger.log('Hitting v1.module');
     UserModule,
     UserTypeModule,
     TagModule,
+    ResourceModule,
   ],
 })
 export class V1Module {}


### PR DESCRIPTION
Added resource to v1 module and export `TypeOrmModule` in resource.module.ts rather than `ResourceEntity`.

Tested in Postman and was able to retrieve added resource:
![image](https://github.com/user-attachments/assets/6c9dc65f-fb9f-48d8-92b9-d172e3048a5b)
