### PR TITLE
Modify create resource to save tags

### DIFF
--- a/server/src/v1/resource-grade/resource-grade.service.ts
+++ b/server/src/v1/resource-grade/resource-grade.service.ts
@@ -14,18 +14,11 @@ export class ResourceGradeService {
     private readonly resourceGradeRepository: Repository<ResourceGradeEntity>,
   ) {}
 
-  async createResourceGrade(
-    newResourceGradeDTO: NewResourceGradeDTO,
-  ): Promise<void> {
-    const resourceGrade =
-      this.resourceGradeRepository.create(newResourceGradeDTO);
-    await this.resourceGradeRepository.save(resourceGrade);
-  }
-
-  async createResourceGrades(
+  async createMultiple(
     resource: ResourceEntity,
     grades: string[],
   ): Promise<void> {
+    console.log(`Inside createMultiple in ResourceGradeService`);
     const resourceGrades = grades.map((grade) => {
       const newResourceGradeDTO = new NewResourceGradeDTO();
       newResourceGradeDTO.resourceId = resource.id;

--- a/server/src/v1/resource-tag/resource-tag.entity.ts
+++ b/server/src/v1/resource-tag/resource-tag.entity.ts
@@ -1,17 +1,29 @@
-import { Entity, ManyToOne, JoinColumn } from 'typeorm';
-import { BaseEntity } from '../../utils/base.entity.js';
+import { Entity, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { BaseEntity, BaseDTO } from '../../utils/base.entity.js';
 import { ResourceEntity } from '../resource/resource.entity.js';
 import { TagEntity } from '../tag/tag.entity.js';
+import { IntersectionType } from '@nestjs/mapped-types';
 
 @Entity('resource_tag')
 export class ResourceTagEntity extends BaseEntity {
-  @ManyToOne(() => ResourceEntity, { onDelete: 'CASCADE',
-    nullable: false })
+  @ManyToOne(() => ResourceEntity, { onDelete: 'CASCADE', nullable: false })
   @JoinColumn({ name: 'resource_id' })
   resource: Promise<ResourceEntity>;
 
-  @ManyToOne(() => TagEntity, { onDelete: 'CASCADE',
-    nullable: false })
+  @Column({ name: 'resource_id', type: 'uuid' })
+  resourceId: string;
+
+  @ManyToOne(() => TagEntity, { onDelete: 'CASCADE', nullable: false })
   @JoinColumn({ name: 'tag_id' })
   tag: Promise<TagEntity>;
+
+  @Column({ name: 'tag_id', type: 'uuid' })
+  tagId: string;
 }
+
+export class NewResourceTagDTO {
+  resourceId: string;
+  tagId: string;
+}
+
+export class ResourceDTO extends IntersectionType(BaseDTO, NewResourceTagDTO) {}

--- a/server/src/v1/resource-tag/resource-tag.service.ts
+++ b/server/src/v1/resource-tag/resource-tag.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { ResourceTagEntity } from './resource-tag.entity.js';
-import { ResourceEntity } from '../resource/resource.entity.js';
+import { ResourceTagEntity, NewResourceTagDTO } from './resource-tag.entity.js';
 
 @Injectable()
 export class ResourceTagService {
@@ -10,4 +9,15 @@ export class ResourceTagService {
     @InjectRepository(ResourceTagEntity)
     private readonly resourceTagRepository: Repository<ResourceTagEntity>,
   ) {}
+
+  createMultiple(
+    resourceId: string,
+    tagIds: string[],
+  ): Promise<ResourceTagEntity[]> {
+    console.log(`Inside createMultiple in ResourceTagService`);
+    const resourceTags = tagIds.map((tagId) =>
+      this.resourceTagRepository.create({ resourceId, tagId }),
+    );
+    return this.resourceTagRepository.save(resourceTags);
+  }
 }

--- a/server/src/v1/resource/resource.controller.ts
+++ b/server/src/v1/resource/resource.controller.ts
@@ -17,6 +17,10 @@ export class ResourceController {
     @Body('grades') grades: string[],
     @Body('tags') tags: string[],
   ): Promise<ResourceEntity> {
-    return await this.resourceService.create(newResourceDTO, grades, tags);
+    return await this.resourceService.createResourceAndDependentGradesAndTags(
+      newResourceDTO,
+      grades,
+      tags,
+    );
   }
 }

--- a/server/src/v1/resource/resource.module.ts
+++ b/server/src/v1/resource/resource.module.ts
@@ -7,16 +7,14 @@ import { ResourceGradeEntity } from '../resource-grade/resource-grade.entity.js'
 import { ResourceTagEntity } from '../resource-tag/resource-tag.entity.js';
 import { ResourceGradeModule } from '../resource-grade/resource-grade.module.js';
 import { ResourceTagModule } from '../resource-tag/resource-tag.module.js';
+import { TagModule } from '../tag/tag.module.js';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([
-      ResourceEntity,
-      ResourceGradeEntity,
-      ResourceTagEntity,
-    ]),
+    TypeOrmModule.forFeature([ResourceEntity]),
     ResourceGradeModule,
     ResourceTagModule,
+    TagModule,
   ],
   controllers: [ResourceController],
   providers: [ResourceService],

--- a/server/src/v1/resource/resource.service.ts
+++ b/server/src/v1/resource/resource.service.ts
@@ -33,7 +33,11 @@ export class ResourceService {
     }
 
     if (tagNames && tagNames.length > 0) {
-      const tags = await this.tagService.findOrCreateByNames(tagNames);
+      const normalizedTagNames = tagNames.map((tagName) =>
+        tagName.toLowerCase(),
+      );
+      const tags =
+        await this.tagService.findOrCreateByNames(normalizedTagNames);
       const tagIds = tags.map((tag) => tag.id);
       await this.resourceTagService.createMultiple(resource.id, tagIds);
     }

--- a/server/src/v1/tag/tag.module.ts
+++ b/server/src/v1/tag/tag.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
-import { TagEntity } from './tag.entity.js';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { TagEntity } from './tag.entity.js';
+import { TagService } from './tag.service.js';
 
 @Module({
   imports: [TypeOrmModule.forFeature([TagEntity])],
+  providers: [TagService],
+  exports: [TagService],
 })
 export class TagModule {}

--- a/server/src/v1/tag/tag.service.ts
+++ b/server/src/v1/tag/tag.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TagEntity } from './tag.entity.js';
+
+@Injectable()
+export class TagService {
+  constructor(
+    @InjectRepository(TagEntity)
+    private readonly tagRepository: Repository<TagEntity>,
+  ) {}
+
+  async findOrCreateByNames(names: string[]): Promise<TagEntity[]> {
+    console.log(`Inside findOrCreateByNames in TagService`);
+    const tags = await Promise.all(
+      names.map(async (name) => {
+        let tag = await this.tagRepository.findOne({ where: { name } });
+        if (!tag) {
+          tag = this.tagRepository.create({ name });
+          await this.tagRepository.save(tag);
+        }
+        return tag;
+      }),
+    );
+    return tags;
+  }
+}


### PR DESCRIPTION
- createResource endpoint will now save tags, and the relationship between the resource and the tag through the resource_tag table (previously, the endpoint would accept tags but ignore them)
- The service transforms all tag names to lowercase to prevent duplicates due to casing (ex: "practice" and "Practice" will both result in "practice", preventing unintentional duplicates)
- The endpoint does a findOrCreate on tags, so it will always check to see if the tag already exists before attempting to create a new one