### PR TITLE
Fix hero h1 positioning and footer margin

### DIFF
--- a/client/src/components/Footer/Footer.css
+++ b/client/src/components/Footer/Footer.css
@@ -7,7 +7,7 @@ footer {
   position: relative;
   left: 50%;
   transform: translateX(-50%);
-  margin-top: 200px;
+  margin-top: 100px;
   box-sizing: border-box;
 }
 

--- a/client/src/pages/HomePage/HomePage.css
+++ b/client/src/pages/HomePage/HomePage.css
@@ -49,6 +49,7 @@
   margin-bottom: 20px;
   line-height: 1.2;
   word-wrap: break-word;
+  margin-top: 20px;
 }
 
 .hero p {

--- a/client/src/pages/HomePage/HomePage.css
+++ b/client/src/pages/HomePage/HomePage.css
@@ -49,7 +49,7 @@
   margin-bottom: 20px;
   line-height: 1.2;
   word-wrap: break-word;
-  margin-top: 20px;
+  margin-top: 40px;
 }
 
 .hero p {
@@ -606,6 +606,7 @@
   
   .hero h1 {
     font-size: 3.8rem;
+    margin-top: 30px;
   }
   
   .hero p {
@@ -670,6 +671,7 @@
   
   .hero h1 {
     font-size: 3rem;
+    margin-top: 20px;
   }
   
   .hero p {


### PR DESCRIPTION
## Change
- Add top margin to hero h1 to vertically center the hero content better
- Make footer margin smaller (was too large before)